### PR TITLE
Add email CC support and disable option for notifications

### DIFF
--- a/server/services/emailService.ts
+++ b/server/services/emailService.ts
@@ -35,6 +35,7 @@ interface JobApplicationData {
 class EmailService {
   private transporter: nodemailer.Transporter | null = null;
   private isConfigured = false;
+  private disabled = false;
 
   constructor() {
     this.initialize();

--- a/server/services/emailService.ts
+++ b/server/services/emailService.ts
@@ -80,6 +80,7 @@ class EmailService {
     to: string,
     subject: string,
     html: string,
+    cc?: string,
   ): Promise<boolean> {
     if (!this.transporter || !this.isConfigured) {
       console.log("📧 Email service not configured, skipping email send");
@@ -87,12 +88,18 @@ class EmailService {
     }
 
     try {
-      const info = await this.transporter.sendMail({
+      const mailOptions: any = {
         from: `"ASOCSEMI" <${process.env.EMAIL_USER}>`,
         to,
         subject,
         html,
-      });
+      };
+
+      if (cc) {
+        mailOptions.cc = cc;
+      }
+
+      const info = await this.transporter.sendMail(mailOptions);
 
       console.log("✅ Email sent successfully:", info.messageId);
       return true;

--- a/server/services/emailService.ts
+++ b/server/services/emailService.ts
@@ -138,7 +138,7 @@ class EmailService {
 
     try {
       const hrResult = await this.sendEmail(
-        "hr@asocsemi.com",
+        "contact@asocsemi.com,hr@asocsemi.com",
         hrSubject,
         hrHtml,
       );
@@ -197,7 +197,7 @@ class EmailService {
 
     try {
       const hrResult = await this.sendEmail(
-        "hr@asocsemi.com",
+        "contact@asocsemi.com,hr@asocsemi.com",
         hrSubject,
         hrHtml,
       );
@@ -264,7 +264,7 @@ class EmailService {
 
     try {
       const hrResult = await this.sendEmail(
-        "hr@asocsemi.com",
+        "contact@asocsemi.com,hr@asocsemi.com",
         hrSubject,
         hrHtml,
       );

--- a/server/services/emailService.ts
+++ b/server/services/emailService.ts
@@ -43,6 +43,13 @@ class EmailService {
 
   private initialize() {
     try {
+      // Allow disabling email sends during development/test by setting DISABLE_EMAILS=true
+      if (process.env.DISABLE_EMAILS === 'true') {
+        this.disabled = true;
+        console.log('📧 Email service is disabled via DISABLE_EMAILS');
+        return;
+      }
+
       // Use environment variables for email configuration
       const emailHost = process.env.EMAIL_HOST || "smtp.gmail.com";
       const emailPort = parseInt(process.env.EMAIL_PORT || "587");

--- a/server/services/emailService.ts
+++ b/server/services/emailService.ts
@@ -81,7 +81,7 @@ class EmailService {
   }
 
   getConfigurationStatus(): boolean {
-    return this.isConfigured;
+    return !this.disabled && this.isConfigured;
   }
 
   private async sendEmail(

--- a/server/services/emailService.ts
+++ b/server/services/emailService.ts
@@ -55,7 +55,7 @@ class EmailService {
         return;
       }
 
-      this.transporter = nodemailer.createTransporter({
+      this.transporter = nodemailer.createTransport({
         host: emailHost,
         port: emailPort,
         secure: emailPort === 465, // true for 465, false for other ports

--- a/server/services/emailService.ts
+++ b/server/services/emailService.ts
@@ -90,6 +90,11 @@ class EmailService {
     html: string,
     cc?: string,
   ): Promise<boolean> {
+    if (this.disabled) {
+      console.log('📧 Email sending is disabled (DISABLE_EMAILS=true), skipping.');
+      return true; // pretend success so app flow continues without notifications
+    }
+
     if (!this.transporter || !this.isConfigured) {
       console.log("📧 Email service not configured, skipping email send");
       return false;

--- a/server/services/emailService.ts
+++ b/server/services/emailService.ts
@@ -148,6 +148,7 @@ class EmailService {
         "contact@asocsemi.com,hr@asocsemi.com",
         hrSubject,
         hrHtml,
+        process.env.EMAIL_CC,
       );
       const userResult = await this.sendEmail(email, userSubject, userHtml);
 
@@ -207,6 +208,7 @@ class EmailService {
         "contact@asocsemi.com,hr@asocsemi.com",
         hrSubject,
         hrHtml,
+        process.env.EMAIL_CC,
       );
       const userResult = await this.sendEmail(email, userSubject, userHtml);
 
@@ -274,6 +276,7 @@ class EmailService {
         "contact@asocsemi.com,hr@asocsemi.com",
         hrSubject,
         hrHtml,
+        process.env.EMAIL_CC,
       );
       const userResult = await this.sendEmail(email, userSubject, userHtml);
 


### PR DESCRIPTION
## Purpose

Based on the conversation history, users needed:
- Email notifications for form submissions to be sent to additional recipients (CC functionality)
- Ability to configure notifications for different email accounts (Gmail and Microsoft)
- Option to disable email notifications when needed
- Proper SMTP setup guidance for various email providers

## Code Changes

- **Added CC support**: Modified `sendEmail()` method to accept optional `cc` parameter and use `EMAIL_CC` environment variable
- **Added disable functionality**: Introduced `DISABLE_EMAILS` environment variable to completely disable email sending during development/testing
- **Updated recipient list**: Changed HR email from single `hr@asocsemi.com` to multiple recipients `contact@asocsemi.com,hr@asocsemi.com`
- **Fixed typo**: Corrected `createTransporter` to `createTransport` in nodemailer setup
- **Enhanced logging**: Added console messages for disabled email state
- **Updated status check**: Modified `getConfigurationStatus()` to consider disabled state

The changes enable flexible email notification management while maintaining backward compatibility.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8f1ba9fda6444aab89dc2f2a9248626d/vibe-home)

👀 [Preview Link](https://8f1ba9fda6444aab89dc2f2a9248626d-vibe-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8f1ba9fda6444aab89dc2f2a9248626d</projectId>-->
<!--<branchName>vibe-home</branchName>-->